### PR TITLE
Fix false shipping cost entry in Delivery Note

### DIFF
--- a/optimusland/public/js/delivery_note.js
+++ b/optimusland/public/js/delivery_note.js
@@ -10,9 +10,8 @@ frappe.ui.form.on('Delivery Note', {
                             label: __('Custom Shipping Cost'),
                             fieldname: 'shipping_cost',
                             fieldtype: 'Currency',
-                            description: __('Enter a custom shipping cost amount (must be greater than zero)'),
-                            reqd: 1,
-                            min: 0.01
+                            description: __('Enter a custom shipping cost amount (set to zero to clear)'),
+                            reqd: 0
                         },
                         {
                             label: __('Purchase Invoice'),
@@ -46,7 +45,7 @@ frappe.ui.form.on('Delivery Note', {
                         
                         // Ask for confirmation
                         frappe.confirm(
-                            __('Are you sure you want to add shipping cost? This action cannot be undone.'),
+                            __('Are you sure you want to update shipping cost?'),
                             function() {
                                 // Call the server method with the form values
                                 frappe.call({
@@ -73,6 +72,31 @@ frappe.ui.form.on('Delivery Note', {
                 
                 d.show();
             }).addClass("btn-danger");
+
+            if (frm.doc.custom_is_shipping_cost_added) {
+                frm.add_custom_button(__('Remove Shipping Cost'), function () {
+                    frappe.confirm(
+                        __('Are you sure you want to remove the shipping cost from this Delivery Note?'),
+                        function() {
+                            frappe.call({
+                                method: "optimusland.utils.delivery_note.remove_shipping_cost",
+                                args: {
+                                    delivery_note_name: frm.doc.name
+                                },
+                                callback: function (response) {
+                                    if (response.message) {
+                                        frappe.show_alert({
+                                            message: __('Shipping Cost removed successfully'),
+                                            indicator: 'green'
+                                        });
+                                        frm.reload_doc();
+                                    }
+                                }
+                            });
+                        }
+                    );
+                }).addClass("btn-danger");
+            }
         }
     }
 });

--- a/optimusland/utils/delivery_note.py
+++ b/optimusland/utils/delivery_note.py
@@ -46,3 +46,31 @@ def add_shipping_cost(delivery_note_name: str, shipping_cost: float, purchase_in
     )
 
     return True
+
+
+@frappe.whitelist()
+def remove_shipping_cost(delivery_note_name: str):
+    """Remove shipping cost from a Delivery Note"""
+
+    doc = frappe.get_doc("Delivery Note", delivery_note_name)
+
+    # Return if the delivery note is not found or is not submitted
+    if not doc or doc.docstatus != 1:
+        frappe.throw("Delivery Note not found or not submitted.")
+
+    # Return if shipping cost was never added
+    if not doc.custom_is_shipping_cost_added:
+        frappe.throw("No shipping cost to remove.")
+
+    frappe.db.set_value("Delivery Note", delivery_note_name, {
+        "custom_shipping_cost": 0,
+        "custom_shipping_rate": 0,
+        "custom_shipping_purchase_invoice": None,
+        "custom_is_shipping_cost_added": 0
+    }, update_modified=False)
+
+    frappe.db.commit()
+
+    doc.add_comment("Info", "Shipping cost removed.")
+
+    return True


### PR DESCRIPTION
Allow users to set the shipping cost to zero or remove it entirely from a Delivery Note. Update the form to make the shipping cost field optional and provide a button to remove the shipping cost with confirmation. Implement server-side logic to handle the removal of shipping costs.

Fixes #44