### PR TITLE
Add warning for shipping cost on Delivery Notes with linked Sales Invoices

### DIFF
--- a/optimusland/optimusland/tests/test_delivery_note_utils.py
+++ b/optimusland/optimusland/tests/test_delivery_note_utils.py
@@ -21,6 +21,7 @@ from optimusland.optimusland.tests import (
 	setup_item_valuation,
 	create_test_batch,
 	create_test_manufacture_stock_entry,
+	create_test_sales_invoice,
 )
 from optimusland.utils.delivery_note import (
 	add_shipping_cost,
@@ -149,6 +150,68 @@ class TestAddRemoveShippingCost(IntegrationTestCase):
 			self.customer.name, self.company.name, self.warehouse.name)
 		with self.assertRaises(frappe.ValidationError):
 			remove_shipping_cost(dn.name)
+
+	def test_add_shipping_cost_with_linked_sales_invoice(self):
+		"""Shipping cost can still be added when linked SI exists, but warning comment is logged."""
+		dn = _create_dn(
+			[{"item_code": self.ship_item.item_code, "qty": 1000, "rate": 0.50}],
+			self.customer.name, self.company.name, self.warehouse.name)
+
+		# Create a submitted Sales Invoice linked to the DN
+		create_test_sales_invoice(
+			[{"item_code": self.ship_item.item_code, "qty": 1000, "rate": 1.00,
+			  "delivery_note": dn.name}],
+			customer=self.customer.name, company=self.company.name,
+			warehouse=self.warehouse.name)
+
+		# Adding shipping should still succeed despite the linked SI
+		self.assertTrue(add_shipping_cost(dn.name, 100.0))
+
+		# Verify shipping was applied
+		dn.reload()
+		self.assertEqual(dn.custom_shipping_cost, 100.0)
+		self.assertEqual(dn.custom_shipping_rate, 0.10)
+		self.assertEqual(dn.custom_is_shipping_cost_added, 1)
+
+		# Verify a warning comment was logged about the linked SI not being updated
+		comments = frappe.get_all("Comment",
+			filters={
+				"reference_doctype": "Delivery Note",
+				"reference_name": dn.name,
+				"comment_type": "Info",
+			},
+			fields=["content"],
+			order_by="creation desc",
+			limit=1,
+		)
+		self.assertTrue(
+			any("NOT updated" in c.content for c in comments),
+			"Expected warning comment about linked SI not being updated",
+		)
+
+	def test_add_shipping_cost_without_linked_sales_invoice(self):
+		"""Adding shipping cost without linked SI should work normally (no warning comment)."""
+		dn = _create_dn(
+			[{"item_code": self.ship_item.item_code, "qty": 1000, "rate": 0.50}],
+			self.customer.name, self.company.name, self.warehouse.name)
+
+		self.assertTrue(add_shipping_cost(dn.name, 100.0))
+
+		# Verify no warning about linked SIs in the comment
+		comments = frappe.get_all("Comment",
+			filters={
+				"reference_doctype": "Delivery Note",
+				"reference_name": dn.name,
+				"comment_type": "Info",
+			},
+			fields=["content"],
+			order_by="creation desc",
+			limit=1,
+		)
+		self.assertFalse(
+			any("NOT updated" in c.content for c in comments),
+			"Expected no warning comment about linked SI",
+		)
 
 
 class TestValidateBatchManufacture(IntegrationTestCase):

--- a/optimusland/public/js/delivery_note.js
+++ b/optimusland/public/js/delivery_note.js
@@ -43,30 +43,54 @@ frappe.ui.form.on('Delivery Note', {
                         // Close the dialog
                         d.hide();
                         
-                        // Ask for confirmation
-                        frappe.confirm(
-                            __('Are you sure you want to update shipping cost?'),
-                            function() {
-                                // Call the server method with the form values
-                                frappe.call({
-                                    method: "optimusland.utils.delivery_note.add_shipping_cost",
-                                    args: {
-                                        delivery_note_name: frm.doc.name,
-                                        shipping_cost: values.shipping_cost,
-                                        purchase_invoice: values.purchase_invoice
-                                    },
-                                    callback: function (response) {
-                                        if (response.message) {
-                                            frappe.show_alert({
-                                                message: __('Shipping Cost updated successfully'),
-                                                indicator: 'green'
-                                            });
-                                            frm.reload_doc();
-                                        }
+                        // Helper to call the server
+                        const doAddShipping = function() {
+                            frappe.call({
+                                method: "optimusland.utils.delivery_note.add_shipping_cost",
+                                args: {
+                                    delivery_note_name: frm.doc.name,
+                                    shipping_cost: values.shipping_cost,
+                                    purchase_invoice: values.purchase_invoice
+                                },
+                                callback: function (response) {
+                                    if (response.message) {
+                                        frappe.show_alert({
+                                            message: __('Shipping Cost updated successfully'),
+                                            indicator: 'green'
+                                        });
+                                        frm.reload_doc();
                                     }
-                                });
+                                }
+                            });
+                        };
+                        
+                        // Check for linked submitted Sales Invoices
+                        frappe.db.get_list('Sales Invoice Item', {
+                            filters: {
+                                delivery_note: frm.doc.name,
+                                docstatus: 1
+                            },
+                            fields: ['parent'],
+                            distinct: true,
+                            limit: 100
+                        }).then(function(items) {
+                            if (items && items.length > 0) {
+                                let siNames = [...new Set(items.map(i => i.parent))].join(', ');
+                                frappe.confirm(
+                                    __('This Delivery Note already has the following Sales Invoice(s):<br><br>• {0}<br><br>If you add shipping cost now:<br><br>✅ <b>The Profit Report will still be correct</b> — it reads shipping directly from the Delivery Note<br><br>❌ <b>The Sales Invoice(s) above will NOT be updated</b> — their cost and profit figures will be missing the shipping cost<br><br><b>Recommended:</b> Cancel the invoice(s) first → add shipping cost → re-create the invoice(s).<br><br>Do you want to proceed anyway?', [siNames]),
+                                    function() {
+                                        doAddShipping();
+                                    }
+                                );
+                            } else {
+                                frappe.confirm(
+                                    __('Are you sure you want to update shipping cost?'),
+                                    function() {
+                                        doAddShipping();
+                                    }
+                                );
                             }
-                        );
+                        });
                     }
                 });
                 

--- a/optimusland/utils/delivery_note.py
+++ b/optimusland/utils/delivery_note.py
@@ -13,7 +13,29 @@ def add_shipping_cost(delivery_note_name: str, shipping_cost: float, purchase_in
     # Return if the delivery note is not found or is not submitted
     if not doc or doc.docstatus != 1:
         frappe.throw("Delivery Note not found or not submitted.")
-    
+
+    # Check for linked submitted Sales Invoices
+    linked_sis = frappe.db.get_all(
+        "Sales Invoice Item",
+        filters={
+            "delivery_note": delivery_note_name,
+            "docstatus": 1
+        },
+        fields=["parent"],
+        distinct=True,
+        pluck="parent"
+    )
+    if linked_sis:
+        si_list = ", ".join(linked_sis)
+        frappe.msgprint(
+            f"This Delivery Note already has linked Sales Invoice(s): <b>{si_list}</b>.<br><br>"
+            "✅ <b>The Profit Report will still be correct</b> — it reads shipping directly from the Delivery Note.<br><br>"
+            "❌ <b>The Sales Invoice(s) above will NOT be updated</b> — their cost and profit figures will be missing the shipping cost.<br><br>"
+            "<b>Recommended:</b> Cancel the invoice(s) first → add shipping cost → re-create the invoice(s).",
+            title="Linked Sales Invoices Detected",
+            indicator="orange"
+        )
+
     # Update the shipping cost field if provided
     if shipping_cost:
         doc.custom_shipping_cost = float(shipping_cost)
@@ -40,10 +62,19 @@ def add_shipping_cost(delivery_note_name: str, shipping_cost: float, purchase_in
         purchase_invoice_link = f'<a href="/app/purchase-invoice/{purchase_invoice}" >{purchase_invoice}</a>'
     else:
         purchase_invoice_link = "N/A"
-    doc.add_comment(
-        "Info",
-        f"Shipping cost of €{shipping_cost} added. Purchase Invoice: {purchase_invoice_link}"
-    )
+
+    if linked_sis:
+        si_list = ", ".join(linked_sis)
+        comment_text = (
+            f"⚠️ Shipping cost of €{shipping_cost} added. "
+            f"Purchase Invoice: {purchase_invoice_link}. "
+            f"Linked Sales Invoice(s) [{si_list}] already exist and were NOT updated. "
+            f"These invoices should be cancelled and re-created to include the shipping cost."
+        )
+    else:
+        comment_text = f"Shipping cost of €{shipping_cost} added. Purchase Invoice: {purchase_invoice_link}"
+
+    doc.add_comment("Info", comment_text)
 
     return True
 


### PR DESCRIPTION
Adding shipping costs to a Delivery Note with an existing submitted Sales Invoice now triggers a warning. The warning informs users that the Sales Invoice will not be updated with the new shipping cost, and recommends canceling the invoice first, adding the shipping cost, and then re-creating the invoice. This change ensures clarity in profit reporting and prevents discrepancies in accounting records.

Fixes #56